### PR TITLE
Fix typo: 'tile' -> 'title'

### DIFF
--- a/01 - Introduction to React Router/01 - Introduction to React Router 6/index.css
+++ b/01 - Introduction to React Router/01 - Introduction to React Router 6/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/01 - Introduction to React Router/01 - Introduction to React Router 6/pages/Vans/Vans.jsx
+++ b/01 - Introduction to React Router/01 - Introduction to React Router 6/pages/Vans/Vans.jsx
@@ -30,7 +30,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/01 - Introduction to React Router/14 - Route Params - part 1/index.css
+++ b/01 - Introduction to React Router/14 - Route Params - part 1/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/01 - Introduction to React Router/14 - Route Params - part 1/pages/Vans.jsx
+++ b/01 - Introduction to React Router/14 - Route Params - part 1/pages/Vans.jsx
@@ -21,7 +21,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <img src={van.imageUrl} />
             <div className="van-info">
                 <h3>{van.name}</h3>

--- a/01 - Introduction to React Router/15 - Route Params - part 2/index.css
+++ b/01 - Introduction to React Router/15 - Route Params - part 2/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/01 - Introduction to React Router/15 - Route Params - part 2/pages/Vans.jsx
+++ b/01 - Introduction to React Router/15 - Route Params - part 2/pages/Vans.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 
 /**
- * Challenge: Wrap the contents of the "van-tile" div in a 
+ * Challenge: Wrap the contents of the "van-title" div in a 
  * Link that sends the user to `/vans/${van-id-here}`.
  */
 
@@ -15,7 +15,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <img src={van.imageUrl} />
             <div className="van-info">
                 <h3>{van.name}</h3>

--- a/01 - Introduction to React Router/16 - Route Params part 3.1 - useParams & challenge/index.css
+++ b/01 - Introduction to React Router/16 - Route Params part 3.1 - useParams & challenge/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/01 - Introduction to React Router/16 - Route Params part 3.1 - useParams & challenge/pages/Vans.jsx
+++ b/01 - Introduction to React Router/16 - Route Params part 3.1 - useParams & challenge/pages/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/01 - Introduction to React Router/17 - Route Params part 3.2 - useParams challenge/index.css
+++ b/01 - Introduction to React Router/17 - Route Params part 3.2 - useParams challenge/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/01 - Introduction to React Router/17 - Route Params part 3.2 - useParams challenge/pages/Vans.jsx
+++ b/01 - Introduction to React Router/17 - Route Params part 3.2 - useParams challenge/pages/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/01 - Nested Routes Intro/index.css
+++ b/02 - Nested Routes/01 - Nested Routes Intro/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/01 - Nested Routes Intro/pages/Vans.jsx
+++ b/02 - Nested Routes/01 - Nested Routes Intro/pages/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/index.css
+++ b/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/pages/Vans.jsx
+++ b/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/pages/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/index.css
+++ b/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/pages/Vans.jsx
+++ b/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/pages/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/04 - Bootstrap the Host pages/index.css
+++ b/02 - Nested Routes/04 - Bootstrap the Host pages/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/04 - Bootstrap the Host pages/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/04 - Bootstrap the Host pages/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/05 - Nesting the host routes/index.css
+++ b/02 - Nested Routes/05 - Nesting the host routes/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/05 - Nesting the host routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/05 - Nesting the host routes/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/06 - Creating the Host Layout/index.css
+++ b/02 - Nested Routes/06 - Creating the Host Layout/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/06 - Creating the Host Layout/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/06 - Creating the Host Layout/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/07 - Relative Paths/index.css
+++ b/02 - Nested Routes/07 - Relative Paths/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/07 - Relative Paths/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/07 - Relative Paths/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/08 - Index Routes/index.css
+++ b/02 - Nested Routes/08 - Index Routes/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/08 - Index Routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/08 - Index Routes/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/09 - To nest or not to nest/index.css
+++ b/02 - Nested Routes/09 - To nest or not to nest/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/09 - To nest or not to nest/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/09 - To nest or not to nest/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/11 - Add Footer/index.css
+++ b/02 - Nested Routes/11 - Add Footer/index.css
@@ -158,12 +158,12 @@ header a:hover {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/11 - Add Footer/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/11 - Add Footer/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/13 - Active Link Styling with NavLink/index.css
+++ b/02 - Nested Routes/13 - Active Link Styling with NavLink/index.css
@@ -180,12 +180,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/13 - Active Link Styling with NavLink/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/13 - Active Link Styling with NavLink/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/index.css
+++ b/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/index.css
@@ -180,12 +180,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/15 - Adding Host Vans Routes/index.css
+++ b/02 - Nested Routes/15 - Adding Host Vans Routes/index.css
@@ -180,12 +180,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/15 - Adding Host Vans Routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/15 - Adding Host Vans Routes/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/index.css
+++ b/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/index.css
@@ -180,12 +180,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/17 - Building out the Host Van Detail Page/index.css
+++ b/02 - Nested Routes/17 - Building out the Host Van Detail Page/index.css
@@ -180,12 +180,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/17 - Building out the Host Van Detail Page/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/17 - Building out the Host Van Detail Page/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/18 - Relative Links/index.css
+++ b/02 - Nested Routes/18 - Relative Links/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/18 - Relative Links/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/18 - Relative Links/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/19 - Back to all vans/index.css
+++ b/02 - Nested Routes/19 - Back to all vans/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/19 - Back to all vans/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/19 - Back to all vans/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/20 - Add host vans id Nested Routes/index.css
+++ b/02 - Nested Routes/20 - Add host vans id Nested Routes/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/20 - Add host vans id Nested Routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/20 - Add host vans id Nested Routes/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/21 - Add the Final Navbar/index.css
+++ b/02 - Nested Routes/21 - Add the Final Navbar/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/21 - Add the Final Navbar/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/21 - Add the Final Navbar/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/22 - Outlet Context/index.css
+++ b/02 - Nested Routes/22 - Outlet Context/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/22 - Outlet Context/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/22 - Outlet Context/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/02 - Nested Routes/23 - Update deployed version on Netlfiy/index.css
+++ b/02 - Nested Routes/23 - Update deployed version on Netlfiy/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/02 - Nested Routes/23 - Update deployed version on Netlfiy/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/23 - Update deployed version on Netlfiy/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/01 - Search Params Intro/index.css
+++ b/03 - Search Params and Links/01 - Search Params Intro/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/01 - Search Params Intro/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/01 - Search Params Intro/pages/Vans/Vans.jsx
@@ -10,7 +10,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/index.css
+++ b/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
     }, [])
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/index.css
+++ b/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
      */
 
     const vanElements = vans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/index.css
+++ b/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/index.css
@@ -192,12 +192,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/index.css
+++ b/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/index.css
@@ -206,12 +206,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/13 - Challenge - conditional rendering practice/index.css
+++ b/03 - Search Params and Links/13 - Challenge - conditional rendering practice/index.css
@@ -206,12 +206,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/13 - Challenge - conditional rendering practice/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/13 - Challenge - conditional rendering practice/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/14 - Fix remaining absolute paths/index.css
+++ b/03 - Search Params and Links/14 - Fix remaining absolute paths/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/14 - Fix remaining absolute paths/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/14 - Fix remaining absolute paths/pages/Vans/Vans.jsx
@@ -24,7 +24,7 @@ export default function Vans() {
      */
     
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={`/vans/${van.id}`}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/15 - Back to all vans/index.css
+++ b/03 - Search Params and Links/15 - Back to all vans/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/15 - Back to all vans/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/15 - Back to all vans/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
     
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={van.id}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/16 - Link state/index.css
+++ b/03 - Search Params and Links/16 - Link state/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/16 - Link state/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/16 - Link state/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
     
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link to={van.id}>
                 <img src={van.imageUrl} />
                 <div className="van-info">

--- a/03 - Search Params and Links/17 - useLocation/index.css
+++ b/03 - Search Params and Links/17 - useLocation/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/17 - useLocation/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/17 - useLocation/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link 
                 to={van.id} 
                 state={{ search: searchParams.toString() }}

--- a/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/index.css
+++ b/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link 
                 to={van.id} 
                 state={{ search: `?${searchParams.toString()}` }}

--- a/03 - Search Params and Links/19 - 404 Page/index.css
+++ b/03 - Search Params and Links/19 - 404 Page/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/19 - 404 Page/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/19 - 404 Page/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link 
                 to={van.id} 
                 state={{ 

--- a/03 - Search Params and Links/20 - Happy Path vs Sad Path/index.css
+++ b/03 - Search Params and Links/20 - Happy Path vs Sad Path/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/20 - Happy Path vs Sad Path/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/20 - Happy Path vs Sad Path/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link 
                 to={van.id} 
                 state={{ 

--- a/03 - Search Params and Links/21 - Quick update to our fetching code/index.css
+++ b/03 - Search Params and Links/21 - Quick update to our fetching code/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/21 - Quick update to our fetching code/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/21 - Quick update to our fetching code/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link 
                 to={van.id} 
                 state={{ 

--- a/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/index.css
+++ b/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/pages/Vans/Vans.jsx
@@ -22,7 +22,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/index.css
+++ b/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/pages/Vans/Vans.jsx
@@ -25,7 +25,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/01 - Loaders Intro/index.css
+++ b/04 - Loaders and Errors/01 - Loaders Intro/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/01 - Loaders Intro/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/01 - Loaders Intro/pages/Vans/Vans.jsx
@@ -31,7 +31,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/03 - Setting up the data router/index.css
+++ b/04 - Loaders and Errors/03 - Setting up the data router/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/03 - Setting up the data router/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/03 - Setting up the data router/pages/Vans/Vans.jsx
@@ -31,7 +31,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/05 - Challenge - Vans List Loader/index.css
+++ b/04 - Loaders and Errors/05 - Challenge - Vans List Loader/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/05 - Challenge - Vans List Loader/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/05 - Challenge - Vans List Loader/pages/Vans/Vans.jsx
@@ -40,7 +40,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/index.css
+++ b/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/pages/Vans/Vans.jsx
@@ -42,7 +42,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/index.css
+++ b/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/pages/Vans/Vans.jsx
@@ -44,7 +44,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/11 - Add errorElement to vans route/index.css
+++ b/04 - Loaders and Errors/11 - Add errorElement to vans route/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/11 - Add errorElement to vans route/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/11 - Add errorElement to vans route/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/04 - Loaders and Errors/12 - useRouteError/index.css
+++ b/04 - Loaders and Errors/12 - useRouteError/index.css
@@ -205,12 +205,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/04 - Loaders and Errors/12 - useRouteError/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/12 - useRouteError/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/01 - Initial Login Form/index.css
+++ b/05 - Actions and Protected Routes/01 - Initial Login Form/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/01 - Initial Login Form/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/01 - Initial Login Form/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/index.css
+++ b/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/index.css
+++ b/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/index.css
+++ b/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/index.css
+++ b/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/index.css
+++ b/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/17 - Pass message to Login page/index.css
+++ b/05 - Actions and Protected Routes/17 - Pass message to Login page/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/17 - Pass message to Login page/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/17 - Pass message to Login page/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/index.css
+++ b/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/index.css
+++ b/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/21 - useNavigate()/index.css
+++ b/05 - Actions and Protected Routes/21 - useNavigate()/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/21 - useNavigate()/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/21 - useNavigate()/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/24 - Add form action to VanLife/index.css
+++ b/05 - Actions and Protected Routes/24 - Add form action to VanLife/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/24 - Add form action to VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/24 - Add form action to VanLife/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/27 - Get form data in VanLife/index.css
+++ b/05 - Actions and Protected Routes/27 - Get form data in VanLife/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/27 - Get form data in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/27 - Get form data in VanLife/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/28 - Use data in action to log in/index.css
+++ b/05 - Actions and Protected Routes/28 - Use data in action to log in/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/28 - Use data in action to log in/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/28 - Use data in action to log in/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/29 - Better but still fake auth/index.css
+++ b/05 - Actions and Protected Routes/29 - Better but still fake auth/index.css
@@ -219,12 +219,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/29 - Better but still fake auth/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/29 - Better but still fake auth/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/index.css
+++ b/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/31 - Form replace/index.css
+++ b/05 - Actions and Protected Routes/31 - Form replace/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/31 - Form replace/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/31 - Form replace/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/34 - Action error handling in VanLife/index.css
+++ b/05 - Actions and Protected Routes/34 - Action error handling in VanLife/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/34 - Action error handling in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/34 - Action error handling in VanLife/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/36 - useNavigation in VanLife/index.css
+++ b/05 - Actions and Protected Routes/36 - useNavigation in VanLife/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/36 - useNavigation in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/36 - useNavigation in VanLife/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/05 - Actions and Protected Routes/40 - redirectTo in VanLife/index.css
+++ b/05 - Actions and Protected Routes/40 - redirectTo in VanLife/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/05 - Actions and Protected Routes/40 - redirectTo in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/40 - redirectTo in VanLife/pages/Vans/Vans.jsx
@@ -18,7 +18,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/06 - Deferred Data/03 - defer getVans()/index.css
+++ b/06 - Deferred Data/03 - defer getVans()/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/03 - defer getVans()/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/03 - defer getVans()/pages/Vans/Vans.jsx
@@ -30,7 +30,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/06 - Deferred Data/05 - Await in Vans route/index.css
+++ b/06 - Deferred Data/05 - Await in Vans route/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/05 - Await in Vans route/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/05 - Await in Vans route/pages/Vans/Vans.jsx
@@ -31,7 +31,7 @@ export default function Vans() {
         : vans
 
     const vanElements = displayedVans.map(van => (
-        <div key={van.id} className="van-tile">
+        <div key={van.id} className="van-title">
             <Link
                 to={van.id}
                 state={{

--- a/06 - Deferred Data/06 - Await vans refactor/index.css
+++ b/06 - Deferred Data/06 - Await vans refactor/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/06 - Await vans refactor/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/06 - Await vans refactor/pages/Vans/Vans.jsx
@@ -44,7 +44,7 @@ export default function Vans() {
                         : vans
 
                     const vanElements = displayedVans.map(van => (
-                        <div key={van.id} className="van-tile">
+                        <div key={van.id} className="van-title">
                             <Link
                                 to={van.id}
                                 state={{

--- a/06 - Deferred Data/08 - Suspense in VanLife/index.css
+++ b/06 - Deferred Data/08 - Suspense in VanLife/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/08 - Suspense in VanLife/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/08 - Suspense in VanLife/pages/Vans/Vans.jsx
@@ -44,7 +44,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/index.css
+++ b/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/pages/Vans/Vans.jsx
@@ -40,7 +40,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/10 - errorElements in remaining van loading pages/index.css
+++ b/06 - Deferred Data/10 - errorElements in remaining van loading pages/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/10 - errorElements in remaining van loading pages/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/10 - errorElements in remaining van loading pages/pages/Vans/Vans.jsx
@@ -53,7 +53,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/11 - Placeholders are gone/index.css
+++ b/06 - Deferred Data/11 - Placeholders are gone/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/11 - Placeholders are gone/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/11 - Placeholders are gone/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/12 - Cloud Firestore setup/index.css
+++ b/06 - Deferred Data/12 - Cloud Firestore setup/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/12 - Cloud Firestore setup/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/12 - Cloud Firestore setup/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/13 - Cloud Firestore Code Setup/index.css
+++ b/06 - Deferred Data/13 - Cloud Firestore Code Setup/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/13 - Cloud Firestore Code Setup/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/13 - Cloud Firestore Code Setup/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/14 - Collection reference and getVans() function/index.css
+++ b/06 - Deferred Data/14 - Collection reference and getVans() function/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/14 - Collection reference and getVans() function/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/14 - Collection reference and getVans() function/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/15 - Create getVan() function/index.css
+++ b/06 - Deferred Data/15 - Create getVan() function/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/15 - Create getVan() function/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/15 - Create getVan() function/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/16 - Refactor getHostVans function/index.css
+++ b/06 - Deferred Data/16 - Refactor getHostVans function/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/16 - Refactor getHostVans function/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/16 - Refactor getHostVans function/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/17 - Final Loose Ends/index.css
+++ b/06 - Deferred Data/17 - Final Loose Ends/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/17 - Final Loose Ends/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/17 - Final Loose Ends/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{

--- a/06 - Deferred Data/18 - Outro/index.css
+++ b/06 - Deferred Data/18 - Outro/index.css
@@ -223,12 +223,12 @@ footer {
     margin-top: 57px;
 }
 
-.van-tile a {
+.van-title a {
     color: #161616;
     text-decoration: none;    
 }
 
-.van-tile img {
+.van-title img {
     max-width: 100%;
     border-radius: 5px;
 }

--- a/06 - Deferred Data/18 - Outro/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/18 - Outro/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
             : vans
 
         const vanElements = displayedVans.map(van => (
-            <div key={van.id} className="van-tile">
+            <div key={van.id} className="van-title">
                 <Link
                     to={van.id}
                     state={{


### PR DESCRIPTION
Fixing the typo `tile` to `title` in all the CSS & JS relevant files.