### PR TITLE
Adding 'alt' attribute to img element

### DIFF
--- a/01 - Introduction to React Router/01 - Introduction to React Router 6/pages/Vans/VanDetail.jsx
+++ b/01 - Introduction to React Router/01 - Introduction to React Router 6/pages/Vans/VanDetail.jsx
@@ -25,7 +25,7 @@ export default function VanDetail() {
                 <Await resolve={loaderData.van}>
                     {(van) => (
                         <div className="van-detail">
-                            <img src={van.imageUrl} />
+                            <img alt={van.name} src={van.imageUrl} />
                             <i className={`van-type ${van.type} selected`}>
                                 {van.type}
                             </i>

--- a/01 - Introduction to React Router/01 - Introduction to React Router 6/pages/Vans/Vans.jsx
+++ b/01 - Introduction to React Router/01 - Introduction to React Router 6/pages/Vans/Vans.jsx
@@ -38,7 +38,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/01 - Introduction to React Router/14 - Route Params - part 1/pages/Vans.jsx
+++ b/01 - Introduction to React Router/14 - Route Params - part 1/pages/Vans.jsx
@@ -22,7 +22,7 @@ export default function Vans() {
 
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
-            <img src={van.imageUrl} />
+            <img alt={van.name} src={van.imageUrl} />
             <div className="van-info">
                 <h3>{van.name}</h3>
                 <p>${van.price}<span>/day</span></p>

--- a/01 - Introduction to React Router/15 - Route Params - part 2/pages/Vans.jsx
+++ b/01 - Introduction to React Router/15 - Route Params - part 2/pages/Vans.jsx
@@ -16,7 +16,7 @@ export default function Vans() {
 
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
-            <img src={van.imageUrl} />
+            <img alt={van.name} src={van.imageUrl} />
             <div className="van-info">
                 <h3>{van.name}</h3>
                 <p>${van.price}<span>/day</span></p>

--- a/01 - Introduction to React Router/16 - Route Params part 3.1 - useParams & challenge/pages/Vans.jsx
+++ b/01 - Introduction to React Router/16 - Route Params part 3.1 - useParams & challenge/pages/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/01 - Introduction to React Router/17 - Route Params part 3.2 - useParams challenge/pages/Vans.jsx
+++ b/01 - Introduction to React Router/17 - Route Params part 3.2 - useParams challenge/pages/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/01 - Nested Routes Intro/pages/VanDetail.jsx
+++ b/02 - Nested Routes/01 - Nested Routes Intro/pages/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/01 - Nested Routes Intro/pages/Vans.jsx
+++ b/02 - Nested Routes/01 - Nested Routes Intro/pages/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/pages/VanDetail.jsx
+++ b/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/pages/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/pages/Vans.jsx
+++ b/02 - Nested Routes/02 - Fixing the Navbar with a Layout Route/pages/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/pages/VanDetail.jsx
+++ b/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/pages/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/pages/Vans.jsx
+++ b/02 - Nested Routes/03 - Fixing the Navbar with a Layout Route part 2/pages/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/04 - Bootstrap the Host pages/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/04 - Bootstrap the Host pages/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/04 - Bootstrap the Host pages/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/04 - Bootstrap the Host pages/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/05 - Nesting the host routes/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/05 - Nesting the host routes/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/05 - Nesting the host routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/05 - Nesting the host routes/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/06 - Creating the Host Layout/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/06 - Creating the Host Layout/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/06 - Creating the Host Layout/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/06 - Creating the Host Layout/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/07 - Relative Paths/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/07 - Relative Paths/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/07 - Relative Paths/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/07 - Relative Paths/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/08 - Index Routes/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/08 - Index Routes/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/08 - Index Routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/08 - Index Routes/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/09 - To nest or not to nest/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/09 - To nest or not to nest/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/09 - To nest or not to nest/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/09 - To nest or not to nest/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/11 - Add Footer/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/11 - Add Footer/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/11 - Add Footer/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/11 - Add Footer/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/13 - Active Link Styling with NavLink/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/13 - Active Link Styling with NavLink/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/13 - Active Link Styling with NavLink/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/13 - Active Link Styling with NavLink/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/14 - Active Link Styling with NavLink - Part 2/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/15 - Adding Host Vans Routes/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/15 - Adding Host Vans Routes/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/15 - Adding Host Vans Routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/15 - Adding Host Vans Routes/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/16 - Optional Side Quest - Building out the Host Vans List and Detail Pages/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/17 - Building out the Host Van Detail Page/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/17 - Building out the Host Van Detail Page/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/17 - Building out the Host Van Detail Page/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/17 - Building out the Host Van Detail Page/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/18 - Relative Links/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/18 - Relative Links/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/18 - Relative Links/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/18 - Relative Links/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/19 - Back to all vans/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/19 - Back to all vans/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/19 - Back to all vans/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/19 - Back to all vans/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/20 - Add host vans id Nested Routes/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/20 - Add host vans id Nested Routes/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/20 - Add host vans id Nested Routes/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/20 - Add host vans id Nested Routes/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/21 - Add the Final Navbar/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/21 - Add the Final Navbar/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/21 - Add the Final Navbar/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/21 - Add the Final Navbar/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/22 - Outlet Context/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/22 - Outlet Context/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/22 - Outlet Context/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/22 - Outlet Context/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/02 - Nested Routes/23 - Update deployed version on Netlfiy/pages/Vans/VanDetail.jsx
+++ b/02 - Nested Routes/23 - Update deployed version on Netlfiy/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/02 - Nested Routes/23 - Update deployed version on Netlfiy/pages/Vans/Vans.jsx
+++ b/02 - Nested Routes/23 - Update deployed version on Netlfiy/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/01 - Search Params Intro/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/01 - Search Params Intro/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/01 - Search Params Intro/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/01 - Search Params Intro/pages/Vans/Vans.jsx
@@ -12,7 +12,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/03 - Challenge - Set up search params in VanLife/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/05 - Challenge - Filter the vans in VanLife/pages/Vans/Vans.jsx
@@ -22,7 +22,7 @@ export default function Vans() {
     const vanElements = vans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/07 - Challenge - Filter the vans with Links/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
     const vanElements = displayedVans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/09 - Challenge - Filter the vans with a setter function/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
     const vanElements = displayedVans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/13 - Challenge - conditional rendering practice/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/13 - Challenge - conditional rendering practice/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/13 - Challenge - conditional rendering practice/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/13 - Challenge - conditional rendering practice/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
     const vanElements = displayedVans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/14 - Fix remaining absolute paths/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/14 - Fix remaining absolute paths/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/14 - Fix remaining absolute paths/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/14 - Fix remaining absolute paths/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
     const vanElements = displayedVans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={`/vans/${van.id}`}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/15 - Back to all vans/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/15 - Back to all vans/pages/Vans/VanDetail.jsx
@@ -15,7 +15,7 @@ export default function VanDetail() {
         <div className="van-detail-container">
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/15 - Back to all vans/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/15 - Back to all vans/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
     const vanElements = displayedVans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={van.id}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/16 - Link state/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/16 - Link state/pages/Vans/VanDetail.jsx
@@ -21,7 +21,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/16 - Link state/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/16 - Link state/pages/Vans/Vans.jsx
@@ -20,7 +20,7 @@ export default function Vans() {
     const vanElements = displayedVans.map(van => (
         <div key={van.id} className="van-tile">
             <Link to={van.id}>
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/17 - useLocation/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/17 - useLocation/pages/Vans/VanDetail.jsx
@@ -21,7 +21,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/17 - useLocation/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/17 - useLocation/pages/Vans/Vans.jsx
@@ -23,7 +23,7 @@ export default function Vans() {
                 to={van.id} 
                 state={{ search: searchParams.toString() }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/pages/Vans/VanDetail.jsx
@@ -35,7 +35,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/18 - Challenge - conditionally render the back button text/pages/Vans/Vans.jsx
@@ -23,7 +23,7 @@ export default function Vans() {
                 to={van.id} 
                 state={{ search: `?${searchParams.toString()}` }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/19 - 404 Page/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/19 - 404 Page/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/19 - 404 Page/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/19 - 404 Page/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter 
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/20 - Happy Path vs Sad Path/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/20 - Happy Path vs Sad Path/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/20 - Happy Path vs Sad Path/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/20 - Happy Path vs Sad Path/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter 
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/21 - Quick update to our fetching code/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/21 - Quick update to our fetching code/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/21 - Quick update to our fetching code/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/21 - Quick update to our fetching code/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter 
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/22 - Coding the Sad Path - Loading state/pages/Vans/Vans.jsx
@@ -30,7 +30,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/pages/Vans/VanDetail.jsx
+++ b/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/pages/Vans/Vans.jsx
+++ b/03 - Search Params and Links/23 - Coding the Sad Path - Error Handling/pages/Vans/Vans.jsx
@@ -33,7 +33,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/01 - Loaders Intro/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/01 - Loaders Intro/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/01 - Loaders Intro/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/01 - Loaders Intro/pages/Vans/Vans.jsx
@@ -39,7 +39,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/03 - Setting up the data router/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/03 - Setting up the data router/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/03 - Setting up the data router/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/03 - Setting up the data router/pages/Vans/Vans.jsx
@@ -39,7 +39,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/05 - Challenge - Vans List Loader/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/05 - Challenge - Vans List Loader/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/05 - Challenge - Vans List Loader/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/05 - Challenge - Vans List Loader/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/07 - Challenge - useLoaderData in Vans List page/pages/Vans/Vans.jsx
@@ -50,7 +50,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/08 - Use the loader data instead of the useEffect/pages/Vans/Vans.jsx
@@ -52,7 +52,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/11 - Add errorElement to vans route/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/11 - Add errorElement to vans route/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/11 - Add errorElement to vans route/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/11 - Add errorElement to vans route/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/04 - Loaders and Errors/12 - useRouteError/pages/Vans/VanDetail.jsx
+++ b/04 - Loaders and Errors/12 - useRouteError/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/04 - Loaders and Errors/12 - useRouteError/pages/Vans/Vans.jsx
+++ b/04 - Loaders and Errors/12 - useRouteError/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/01 - Initial Login Form/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/01 - Initial Login Form/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/05 - Actions and Protected Routes/01 - Initial Login Form/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/01 - Initial Login Form/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/02 - Note from the future - importing image assets in Vite/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/11 - Challenge - Protected Routes in VanLife - Part 1/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/pages/Vans/VanDetail.jsx
@@ -27,7 +27,7 @@ export default function VanDetail() {
             
             {van ? (
                 <div className="van-detail">
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <i className={`van-type ${van.type} selected`}>
                         {van.type}
                     </i>

--- a/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/12 - Aside challenge - move remaining fetching to loaders - Part 1/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/13 - Aside challenge - move remaining fetching to loaders - part 2/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/14 - Challenge - Protected Routes in VanLife - Part 2/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/17 - Pass message to Login page/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/17 - Pass message to Login page/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/17 - Pass message to Login page/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/17 - Pass message to Login page/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/19 - Setting up for authentication - happy path/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/20 - Setting up for authentication - sad path/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/21 - useNavigate()/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/21 - useNavigate()/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/21 - useNavigate()/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/21 - useNavigate()/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/24 - Add form action to VanLife/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/24 - Add form action to VanLife/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/24 - Add form action to VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/24 - Add form action to VanLife/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/27 - Get form data in VanLife/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/27 - Get form data in VanLife/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/27 - Get form data in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/27 - Get form data in VanLife/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/28 - Use data in action to log in/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/28 - Use data in action to log in/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/28 - Use data in action to log in/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/28 - Use data in action to log in/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/29 - Better but still fake auth/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/29 - Better but still fake auth/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/29 - Better but still fake auth/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/29 - Better but still fake auth/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/30 - Challenge - send user to host route after log in/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/31 - Form replace/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/31 - Form replace/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/31 - Form replace/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/31 - Form replace/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/34 - Action error handling in VanLife/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/34 - Action error handling in VanLife/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/34 - Action error handling in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/34 - Action error handling in VanLife/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/36 - useNavigation in VanLife/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/36 - useNavigation in VanLife/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/36 - useNavigation in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/36 - useNavigation in VanLife/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/05 - Actions and Protected Routes/40 - redirectTo in VanLife/pages/Vans/VanDetail.jsx
+++ b/05 - Actions and Protected Routes/40 - redirectTo in VanLife/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/05 - Actions and Protected Routes/40 - redirectTo in VanLife/pages/Vans/Vans.jsx
+++ b/05 - Actions and Protected Routes/40 - redirectTo in VanLife/pages/Vans/Vans.jsx
@@ -26,7 +26,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/03 - defer getVans()/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/03 - defer getVans()/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/03 - defer getVans()/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/03 - defer getVans()/pages/Vans/Vans.jsx
@@ -38,7 +38,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/05 - Await in Vans route/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/05 - Await in Vans route/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/05 - Await in Vans route/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/05 - Await in Vans route/pages/Vans/Vans.jsx
@@ -39,7 +39,7 @@ export default function Vans() {
                     type: typeFilter
                 }}
             >
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <div className="van-info">
                     <h3>{van.name}</h3>
                     <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/06 - Await vans refactor/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/06 - Await vans refactor/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/06 - Await vans refactor/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/06 - Await vans refactor/pages/Vans/Vans.jsx
@@ -52,7 +52,7 @@ export default function Vans() {
                                     type: typeFilter
                                 }}
                             >
-                                <img src={van.imageUrl} />
+                                <img alt={van.name} src={van.imageUrl} />
                                 <div className="van-info">
                                     <h3>{van.name}</h3>
                                     <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/08 - Suspense in VanLife/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/08 - Suspense in VanLife/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/08 - Suspense in VanLife/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/08 - Suspense in VanLife/pages/Vans/Vans.jsx
@@ -52,7 +52,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/09 - Putting it all together - defer, Await, Suspense in HostVans/pages/Vans/Vans.jsx
@@ -48,7 +48,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/10 - errorElements in remaining van loading pages/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/10 - errorElements in remaining van loading pages/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/10 - errorElements in remaining van loading pages/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/10 - errorElements in remaining van loading pages/pages/Vans/Vans.jsx
@@ -61,7 +61,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/11 - Placeholders are gone/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/11 - Placeholders are gone/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/11 - Placeholders are gone/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/11 - Placeholders are gone/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/12 - Cloud Firestore setup/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/12 - Cloud Firestore setup/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/12 - Cloud Firestore setup/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/12 - Cloud Firestore setup/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/13 - Cloud Firestore Code Setup/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/13 - Cloud Firestore Code Setup/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/13 - Cloud Firestore Code Setup/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/13 - Cloud Firestore Code Setup/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/14 - Collection reference and getVans() function/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/14 - Collection reference and getVans() function/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/14 - Collection reference and getVans() function/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/14 - Collection reference and getVans() function/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/15 - Create getVan() function/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/15 - Create getVan() function/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/15 - Create getVan() function/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/15 - Create getVan() function/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/16 - Refactor getHostVans function/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/16 - Refactor getHostVans function/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/16 - Refactor getHostVans function/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/16 - Refactor getHostVans function/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/17 - Final Loose Ends/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/17 - Final Loose Ends/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/17 - Final Loose Ends/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/17 - Final Loose Ends/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>

--- a/06 - Deferred Data/18 - Outro/pages/Vans/VanDetail.jsx
+++ b/06 - Deferred Data/18 - Outro/pages/Vans/VanDetail.jsx
@@ -22,7 +22,7 @@ export default function VanDetail() {
             >&larr; <span>Back to {type} vans</span></Link>
 
             <div className="van-detail">
-                <img src={van.imageUrl} />
+                <img alt={van.name} src={van.imageUrl} />
                 <i className={`van-type ${van.type} selected`}>
                     {van.type}
                 </i>

--- a/06 - Deferred Data/18 - Outro/pages/Vans/Vans.jsx
+++ b/06 - Deferred Data/18 - Outro/pages/Vans/Vans.jsx
@@ -56,7 +56,7 @@ export default function Vans() {
                         type: typeFilter
                     }}
                 >
-                    <img src={van.imageUrl} />
+                    <img alt={van.name} src={van.imageUrl} />
                     <div className="van-info">
                         <h3>{van.name}</h3>
                         <p>${van.price}<span>/day</span></p>


### PR DESCRIPTION
Adding `alt` attribute to `<img />` element to prevent warnings.

```
The required alt attribute specifies an alternate text for an image, if the image cannot be displayed.

The alt attribute provides alternative information for an image if a user for some reason cannot view it (because of slow connection, an error in the src attribute, or if the user uses a screen reader).
```
(src: https://www.w3schools.com/tags/att_img_alt.asp)